### PR TITLE
Fill parameters via environment variables

### DIFF
--- a/datacli/__init__.py
+++ b/datacli/__init__.py
@@ -47,12 +47,18 @@ def from_env_var(env_var_name: str):
 
 
 def has_env_default_factory(field: Field) -> bool:
+    """
+    Check if a field can be filled with an environment variable. This utilizes the explicit naming of the initially
+    anonymous default factory returned by `from_env_var`
+    """
     default_factory = field.default_factory
-    function_name_len = len("_datacli_get_env_var")
     return not (default_factory is MISSING) and default_factory.__qualname__== env_var_default_factory_marker
 
 
 def get_corresponding_env_var(field: Field) -> Optional[str]:
+    """
+    Utilize the dyanic name assigned to the initially anonymous default factory returned by `from_env_var`.
+    """
     result = None
     if has_env_default_factory(field):
         result = field.default_factory.__name__

--- a/datacli/__init__.py
+++ b/datacli/__init__.py
@@ -79,7 +79,6 @@ def check_fields_with_env_defaults(instance):
     for field in fields(type(instance)):
         field_content = getattr(instance, field.name)
         corresponding_env_var = get_corresponding_env_var(field)
-        print(corresponding_env_var)
         if corresponding_env_var and field_content == "":
             raise ValueError(f"{field.name} not set, either supply either of the arguments {list(get_names(field))} " \
                     + f"or set environment variable {corresponding_env_var}")

--- a/datacli/__init__.py
+++ b/datacli/__init__.py
@@ -1,3 +1,6 @@
+import os
+from typing import List, Optional, Tuple
+
 """A library for building simple CLIs from dataclasses.
 
 DataCLI is based on argparse.
@@ -21,18 +24,48 @@ def get_names(field):
         yield "--" + field.name.replace("_", "-")
 
 
+def from_env_var(env_var_name: str):
+    """add a default factory to extract the cli argument from env"""
+    def _get() -> str:
+        return os.getenv(env_var_name, f"")
+    return _get
+
+
 def make_parser(cls):
     """Create an argument parser from a dataclass."""
     parser = ArgumentParser()
 
     for field in fields(cls):
+        corresponding_env_var = field.metadata.get("env_var")
+
         required = (field.default is MISSING
                     and field.default_factory is MISSING)
+
+        env_var_default: Optional[str] = None
+        help_text = field.metadata.get("help")
+
+        if corresponding_env_var:
+            required = False
+            help_text = help_text + f", can also be set with environment variable {corresponding_env_var}"
+            env_var_default = os.getenv(corresponding_env_var, "")
+
         arg_type = field.metadata.get("arg_type", field.type)
+
         parser.add_argument(*get_names(field),
-                            type=arg_type, required=required)
+                            type=arg_type, # type: ignore
+                            help=help_text,
+                            required=required,
+                            default=env_var_default)
 
     return parser
+
+def check_fields_with_env_defaults(instance):
+    for field in fields(type(instance)):
+        corresponding_env_var = field.metadata.get("env_var")
+        if corresponding_env_var and getattr(instance, field.name) == "":
+            error_message = f"{field.name} not set, either supply arguments {list(get_names(field))} " \
+                + f"or set environment variable {corresponding_env_var}"
+            raise ValueError(error_message)
 
 
 def datacli(cls, argv=None):
@@ -40,4 +73,6 @@ def datacli(cls, argv=None):
     parser = make_parser(cls)
     data = {key: val for key, val in vars(parser.parse_args(argv)).items()
             if val is not None}
-    return cls(**data)
+    instance = cls(**data)
+    check_fields_with_env_defaults(instance)
+    return instance

--- a/tests/test_datacli.py
+++ b/tests/test_datacli.py
@@ -1,8 +1,10 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pytest import raises
 
-from datacli import datacli
+from datacli import datacli, from_env_var
+
+import os
 
 
 def test_no_fields():
@@ -35,9 +37,27 @@ def test_optional_fields():
     class Test:
         string: str = "abc"
         integer: int = 10
-    
+
     args = datacli(Test, [])
     assert args == Test("abc", 10)
 
     args = datacli(Test, ["--string", "foo"])
     assert args == Test("foo", 10)
+
+
+def test_environment_variables():
+    ENV_VAR_NAME = "STRING_FOR_TEST_CLI"
+
+    @dataclass
+    class Test:
+        integer: int
+        string: str = field(default_factory=from_env_var(ENV_VAR_NAME))
+
+    with raises(ValueError):
+        datacli(Test, ["--integer", "10"])
+
+    os.environ[ENV_VAR_NAME] = "abcd"
+
+    args = datacli(Test, ["--integer", "10"])
+
+    assert args == Test(10, "abcd")


### PR DESCRIPTION
closes #2 

Adds option to pass required arguments via environment variables. 

Checks if parameters were filled after the dataclass was created in order to produce more helpful error messages that also include the cli parameter as an alternative way of filling the parameter. 